### PR TITLE
Upgrade nicebooks/isbn to v0.8, adapt ISBN13 formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Note that the first published version was v0.8.0. The commits for older versions
 
 ## [Unreleased]
 
+- Changed: Upgrade nicebooks/isbn to v0.8, adapt ISBN13 formatting (#20)
+
 ## 2026-02-07 - v0.8.3
 
 - Changed: Upgrade nicebooks/isbn to v0.6, use RangeService instead of IsbnTools (#9)

--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,14 @@
 	"require": {
 		"php": ">=8.2",
 		"ext-fileinfo": "*",
-		"guzzlehttp/guzzle": "^7.10",
-		"nicebooks/isbn": "^0.6",
-		"phpoffice/phpspreadsheet": "^5.4"
+		"guzzlehttp/guzzle": "^7.14",
+		"nicebooks/isbn": "^0.8",
+		"phpoffice/phpspreadsheet": "^5.8"
 	},
 	"require-dev": {
 		"squizlabs/php_codesniffer": "^4.0",
 		"phpmd/phpmd": "^2.15",
-		"phpstan/phpstan": "^2.1"
+		"phpstan/phpstan": "^2.2"
 	},
 	"autoload": {
 		"psr-4": {

--- a/src/traits/Checks.php
+++ b/src/traits/Checks.php
@@ -1130,7 +1130,11 @@ trait Checks
             $isbnNoHyphens = str_replace('-', '', $isbn);
         }
 
-        return RangeService::format($isbnNoHyphens);
+        $rangeInfo = RangeService::getRangeInfo($isbnNoHyphens);
+        if ($rangeInfo !== null && $rangeInfo->parts !== null) {
+            return implode('-', $rangeInfo->parts);
+        }
+        return $isbnNoHyphens;
     }
 
     protected function checkedIsbnIdentifier(string $position, string $property, string $value): ?string


### PR DESCRIPTION
This PR resolves #20.

nicebooks/isbn is upgraded to v0.8. `Checks::formatIsbn3` now includes the code from `RangeService::format` which was removed in nicebooks/isbn v0.7.

The PR also include some minor updates to other dependencies.