### PR TITLE
Fix PHP 8.4 deprecation warnings for implicit nullable parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Note that the first published version was v0.8.0. The commits for older versions
 
 ## [Unreleased]
 
+- Fixed: PHP 8.4 deprecation warnings for implicit nullable parameters (#22)
 - Changed: Upgrade nicebooks/isbn to v0.8, adapt ISBN13 formatting (#20)
 
 ## 2026-02-07 - v0.8.3

--- a/src/Document.php
+++ b/src/Document.php
@@ -36,7 +36,7 @@ abstract class Document
 
     protected $document = null;
 
-    protected function fromFile(string $filename, string $extension = null): void
+    protected function fromFile(string $filename, ?string $extension = null): void
     {
         $this->checkFile($filename);
         $this->filename = $filename;

--- a/src/FileDocument.php
+++ b/src/FileDocument.php
@@ -14,7 +14,7 @@ use ubfr\c5tools\exceptions\InvalidFileDocumentException;
 
 class FileDocument extends Document
 {
-    public function __construct(string $filename, string $extension = null)
+    public function __construct(string $filename, ?string $extension = null)
     {
         try {
             $this->fromFile($filename, $extension);

--- a/src/JsonReport.php
+++ b/src/JsonReport.php
@@ -24,7 +24,7 @@ class JsonReport extends Report implements interfaces\JsonDocument
 
     protected $jsonItems;
 
-    public function __construct(Document $document, CounterApiRequest $request = null)
+    public function __construct(Document $document, ?CounterApiRequest $request = null)
     {
         if (! $document->isReport()) {
             throw new \InvalidArgumentException('document is not valid for Report');

--- a/src/Report.php
+++ b/src/Report.php
@@ -47,7 +47,7 @@ abstract class Report implements interfaces\CheckedDocument // , \Countable, \It
         $this->parseHeader();
     }
 
-    public static function fromFile(string $filename, string $extension = null): Report
+    public static function fromFile(string $filename, ?string $extension = null): Report
     {
         $document = new FileDocument($filename, $extension);
         if ($document->isJson()) {

--- a/src/TabularReport.php
+++ b/src/TabularReport.php
@@ -17,7 +17,7 @@ use ubfr\c5tools\data\TabularItemList51;
 
 class TabularReport extends Report
 {
-    public function __construct(Document $document, CounterApiRequest $request = null)
+    public function __construct(Document $document, ?CounterApiRequest $request = null)
     {
         if ($document->isJson()) {
             throw new \InvalidArgumentException('document is not valid for tabular Report');

--- a/src/data/ReportFilterList.php
+++ b/src/data/ReportFilterList.php
@@ -20,7 +20,7 @@ class ReportFilterList extends NameValueList
         \ubfr\c5tools\interfaces\CheckedDocument $parent,
         string $position,
         $document,
-        array $filterNames = null
+        ?array $filterNames = null
     ) {
         $this->reportId = $parent->getReportId();
         $this->filtersConfig = $parent->getConfig()->getReportFilters($this->reportId);

--- a/src/exceptions/CounterApiException.php
+++ b/src/exceptions/CounterApiException.php
@@ -53,7 +53,7 @@ class CounterApiException extends \Exception implements
         'Info'
     ];
 
-    public function __construct(Document $document, CounterApiRequest $request = null)
+    public function __construct(Document $document, ?CounterApiRequest $request = null)
     {
         if (! $document->isException()) {
             throw new \InvalidArgumentException("document is not valid for CounterApiException");

--- a/src/traits/Checks.php
+++ b/src/traits/Checks.php
@@ -1124,7 +1124,7 @@ trait Checks
         return null;
     }
 
-    protected function formatIsbn13(string $isbn, string $isbnNoHyphens = null): ?string
+    protected function formatIsbn13(string $isbn, ?string $isbnNoHyphens = null): ?string
     {
         if ($isbnNoHyphens === null) {
             $isbnNoHyphens = str_replace('-', '', $isbn);


### PR DESCRIPTION
This PR resolves #22.